### PR TITLE
Oraclize Random Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,10 @@ so instead use:
 
 
 getMaxPlayers returns `{ [String: '5'] s: 1, e: 0, c: [ 5 ] }`
+
+
+Because need Remix compiler, or to provide mapping: https://ethereum.stackexchange.com/questions/13067/importing-contracts-files-to-ethereum-wallet?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
+```
+import "github.com/oraclize/ethereum-api/oraclizeAPI.sol";
+Source "github.com/oraclize/ethereum-api/oraclizeAPI.sol" not found
+```

--- a/README.md
+++ b/README.md
@@ -155,3 +155,6 @@ Because need Remix compiler, or to provide mapping: https://ethereum.stackexchan
 import "github.com/oraclize/ethereum-api/oraclizeAPI.sol";
 Source "github.com/oraclize/ethereum-api/oraclizeAPI.sol" not found
 ```
+
+
+https://github.com/oraclize/ethereum-studio-examples/blob/master/contracts/lib/oraclizeAPI.sol

--- a/helpers.js
+++ b/helpers.js
@@ -115,7 +115,7 @@ module.exports = class Helpers {
     compileAndDeployCoinFlipOracleContract (options = {}) {
       var input = {
         'CoinFlipOracle.sol': this.loadContract('CoinFlipOracle'),
-        'OraclizeAPI.sol': this.loadContract('OraclizeAPI')
+        'oraclizeAPI.sol': this.loadContract('oraclizeAPI')
       };
       
       let compiled, contractName, bytecode
@@ -124,7 +124,6 @@ module.exports = class Helpers {
         console.log('....compiled CoinFlipOracle.sol OraclizeAPI.sol together successfully....compiled', compiled)
         contractName = 'CoinFlipOracle'
         bytecode = compiled["contracts"][`${contractName}.sol:${contractName}`]["bytecode"]
-        console.log('....compiled CoinFlipOracle.sol OraclizeAPI.sol together successfully....bytecode', bytecode)
       } catch (err) { console.log('ERROR in compilation....')}
       
       var abi = JSON.parse(compiled["contracts"][`${contractName}.sol:${contractName}`]["interface"])
@@ -142,13 +141,15 @@ module.exports = class Helpers {
     }
 
     compileAndDeployCoinFlipOracleContract1File (options ={}) {
+      console.log('****  compileAndDeployCoinFlipOracleContract1File  ****')
+
       var source = this.loadContract('CoinFlipOracle')
 
       let compiled, contractName, bytecode
       let compiledContract
       try {
         compiled = solc.compile(source);
-        console.log('....compiled compileAndDeployCoinFlipOracleContract1File....compiled', compiled)
+        console.log('....compiled compileAndDeployCoinFlipOracleContract1File....compiled\n', compiled)
         
         contractName = 'CoinFlipOracle'
         compiledContract = compiled["contracts"][`:${contractName}`]

--- a/helpers.js
+++ b/helpers.js
@@ -111,4 +111,61 @@ module.exports = class Helpers {
     }  
 
     toWei (E) { return global.web3.toWei(E, 'ether') }
+
+    compileAndDeployCoinFlipOracleContract (options = {}) {
+      var input = {
+        'CoinFlipOracle.sol': this.loadContract('CoinFlipOracle'),
+        'OraclizeAPI.sol': this.loadContract('OraclizeAPI')
+      };
+      
+      let compiled, contractName, bytecode
+      try {
+        compiled = solc.compile({sources: input}, 1);
+        console.log('....compiled CoinFlipOracle.sol OraclizeAPI.sol together successfully....compiled', compiled)
+        contractName = 'CoinFlipOracle'
+        bytecode = compiled["contracts"][`${contractName}.sol:${contractName}`]["bytecode"]
+        console.log('....compiled CoinFlipOracle.sol OraclizeAPI.sol together successfully....bytecode', bytecode)
+      } catch (err) { console.log('ERROR in compilation....')}
+      
+      var abi = JSON.parse(compiled["contracts"][`${contractName}.sol:${contractName}`]["interface"])
+      var contract = global.web3.eth.contract(abi)
+      var gasEstimate = global.web3.eth.estimateGas({ data: bytecode })
+  
+      var deployed = contract.new(Object.assign({
+        from: global.web3.eth.accounts[0],
+        data: bytecode,
+        gas: gasEstimate,
+        gasPrice: 5
+        // value: web3.toWei(1, 'ether')
+      }, options), (error, masterContract) => {})
+      return deployed
+    }
+
+    compileAndDeployCoinFlipOracleContract1File (options ={}) {
+      var source = this.loadContract('CoinFlipOracle')
+
+      let compiled, contractName, bytecode
+      let compiledContract
+      try {
+        compiled = solc.compile(source);
+        console.log('....compiled compileAndDeployCoinFlipOracleContract1File....compiled', compiled)
+        
+        contractName = 'CoinFlipOracle'
+        compiledContract = compiled["contracts"][`:${contractName}`]
+        bytecode = compiledContract["bytecode"]
+      } catch (err) { console.log('ERROR in compilation, no bytecode available')}
+
+      var abi = JSON.parse(compiledContract["interface"])
+      var contract = global.web3.eth.contract(abi)
+      var gasEstimate = global.web3.eth.estimateGas({ data: bytecode })
+
+      var deployed = contract.new(Object.assign({
+        from: global.web3.eth.accounts[0],
+        data: bytecode,
+        gas: gasEstimate,
+        gasPrice: 5
+        // value: web3.toWei(1, 'ether')
+      }, options), (error, masterContract) => {}) // masterContract.address
+      return deployed
+    }
   }

--- a/helpers.js
+++ b/helpers.js
@@ -121,7 +121,6 @@ module.exports = class Helpers {
       let compiled, contractName, bytecode
       try {
         compiled = solc.compile({sources: input}, 1);
-        console.log('....compiled CoinFlipOracle.sol OraclizeAPI.sol together successfully....compiled', compiled)
         contractName = 'CoinFlipOracle'
         bytecode = compiled["contracts"][`${contractName}.sol:${contractName}`]["bytecode"]
       } catch (err) { console.log('ERROR in compilation....')}
@@ -141,8 +140,6 @@ module.exports = class Helpers {
     }
 
     compileAndDeployCoinFlipOracleContract1File (options ={}) {
-      console.log('****  compileAndDeployCoinFlipOracleContract1File  ****')
-
       var source = this.loadContract('CoinFlipOracle')
 
       let compiled, contractName, bytecode

--- a/main.js
+++ b/main.js
@@ -46,7 +46,7 @@ masterContract.createLottery(
     {from: acct1, gas: 4612388, gasPrice: 5, value: wei }
 )
 var lotteryAddress = masterContract.getNewLotteryAddress.call();
-var lotteryContract = getContract('Lottery', lotteryAddress); // *
+var lotteryContract = getContract('Lottery', lotteryAddress);
 
 setEventEmitLogL()
 setEventEmitLogM()

--- a/setup.js
+++ b/setup.js
@@ -29,7 +29,7 @@ const helpers = new Helpers()
 global.masterContract = helpers.compileContractsAndDeployMasterContract1File()
 
 global.balance = helpers.balance
-global.getContract = helpers.getContract.bind(helpers)
+global.getContract = helpers.getContract.bind(helpers) // TODO getContract1File....
 global.toWei = helpers.toWei
 
 console.log(`....MasterContract was deployed and is available as 'masterContract' global object....\n`)

--- a/setup.js
+++ b/setup.js
@@ -25,8 +25,8 @@ global.acct5 = web3.eth.accounts[4]
 
 const helpers = new Helpers()
 
-// global.masterContract = helpers.compileContractsAndDeployMasterContract()
-// global.masterContract = helpers.compileContractsAndDeployMasterContract1File()
+// global.masterContract = helpers.compileContractsAndDeployMasterContract() OLD attempt
+global.masterContract = helpers.compileContractsAndDeployMasterContract1File()
 
 // global.coinFlipOracleContract = helpers.compileAndDeployCoinFlipOracleContract1File()
 global.coinFlipOracleContract = helpers.compileAndDeployCoinFlipOracleContract()

--- a/setup.js
+++ b/setup.js
@@ -26,7 +26,9 @@ global.acct5 = web3.eth.accounts[4]
 const helpers = new Helpers()
 
 // global.masterContract = helpers.compileContractsAndDeployMasterContract()
-global.masterContract = helpers.compileContractsAndDeployMasterContract1File()
+// global.masterContract = helpers.compileContractsAndDeployMasterContract1File()
+global.coinFlipOracleContract = helpers.compileAndDeployCoinFlipOracleContract1File()
+// global.coinFlipOracleContract = helpers.compileAndDeployCoinFlipOracleContract()
 
 global.balance = helpers.balance
 global.getContract = helpers.getContract.bind(helpers) // TODO getContract1File....

--- a/setup.js
+++ b/setup.js
@@ -29,7 +29,7 @@ const helpers = new Helpers()
 global.masterContract = helpers.compileContractsAndDeployMasterContract1File()
 
 // global.coinFlipOracleContract = helpers.compileAndDeployCoinFlipOracleContract1File()
-global.coinFlipOracleContract = helpers.compileAndDeployCoinFlipOracleContract()
+// global.coinFlipOracleContract = helpers.compileAndDeployCoinFlipOracleContract()
 
 global.balance = helpers.balance
 global.getContract = helpers.getContract.bind(helpers) // TODO getContract1File....

--- a/setup.js
+++ b/setup.js
@@ -27,8 +27,9 @@ const helpers = new Helpers()
 
 // global.masterContract = helpers.compileContractsAndDeployMasterContract()
 // global.masterContract = helpers.compileContractsAndDeployMasterContract1File()
-global.coinFlipOracleContract = helpers.compileAndDeployCoinFlipOracleContract1File()
-// global.coinFlipOracleContract = helpers.compileAndDeployCoinFlipOracleContract()
+
+// global.coinFlipOracleContract = helpers.compileAndDeployCoinFlipOracleContract1File()
+global.coinFlipOracleContract = helpers.compileAndDeployCoinFlipOracleContract()
 
 global.balance = helpers.balance
 global.getContract = helpers.getContract.bind(helpers) // TODO getContract1File....

--- a/solidity/CoinFlipOracle.sol
+++ b/solidity/CoinFlipOracle.sol
@@ -1,11 +1,12 @@
 pragma solidity ^0.4.0;
 //import oraclizeAPI_pre0.4.sol when solidity < 0.4.0
-// import "./OraclizeAPI.sol";
+import "./oraclizeAPI.sol";
+
 // June 8 2018
 // import "https://github.com/oraclize/ethereum-api/oraclizeAPI.sol"; // NOT FOUND, URL 
 // import "http://github.com/oraclize/ethereum-api/blob/master/oraclizeAPI.sol";
 // import "github.com/oraclize/ethereum-api/blob/master/oraclizeAPI_0.4.sol";
-import "github.com/oraclize/ethereum-api/oraclizeAPI.sol";
+// import "github.com/oraclize/ethereum-api/oraclizeAPI.sol";
 
 contract CoinFlipOracle is usingOraclize {
 

--- a/solidity/CoinFlipOracle.sol
+++ b/solidity/CoinFlipOracle.sol
@@ -1,0 +1,24 @@
+pragma solidity ^0.4.0;
+//import oraclizeAPI_pre0.4.sol when solidity < 0.4.0
+// import "./OraclizeAPI.sol";
+// June 8 2018
+// import "https://github.com/oraclize/ethereum-api/oraclizeAPI.sol"; // NOT FOUND, URL 
+// import "http://github.com/oraclize/ethereum-api/blob/master/oraclizeAPI.sol";
+// import "github.com/oraclize/ethereum-api/blob/master/oraclizeAPI_0.4.sol";
+import "github.com/oraclize/ethereum-api/oraclizeAPI.sol";
+
+contract CoinFlipOracle is usingOraclize {
+
+    string public result;
+    bytes32 public oraclizeID;
+    // added 'public' to both of these
+    function flipCoin() payable public {
+        oraclizeID = oraclize_query("WolframAlpha", "flip a coin");
+    }    
+
+    function __callback(bytes32 _oraclizeID, string _result) public {
+        if(msg.sender != oraclize_cbAddress()) revert(); // throw;
+        result = _result;
+    }
+
+}

--- a/solidity/Master.sol
+++ b/solidity/Master.sol
@@ -1,5 +1,288 @@
 pragma solidity ^0.4.0;
 
+
+contract OraclizeI {
+    address public cbAddress;
+    function query(uint _timestamp, string _datasource, string _arg) payable returns (bytes32 _id);
+    function query_withGasLimit(uint _timestamp, string _datasource, string _arg, uint _gaslimit) payable returns (bytes32 _id);
+    function query2(uint _timestamp, string _datasource, string _arg1, string _arg2) payable returns (bytes32 _id);
+    function query2_withGasLimit(uint _timestamp, string _datasource, string _arg1, string _arg2, uint _gaslimit) payable returns (bytes32 _id);
+    function getPrice(string _datasource) returns (uint _dsprice);
+    function getPrice(string _datasource, uint gaslimit) returns (uint _dsprice);
+    function useCoupon(string _coupon);
+    function setProofType(byte _proofType);
+    function setConfig(bytes32 _config);
+    function setCustomGasPrice(uint _gasPrice);
+}
+contract OraclizeAddrResolverI {
+    function getAddress() returns (address _addr);
+}
+contract usingOraclize {
+    uint constant day = 60*60*24;
+    uint constant week = 60*60*24*7;
+    uint constant month = 60*60*24*30;
+    byte constant proofType_NONE = 0x00;
+    byte constant proofType_TLSNotary = 0x10;
+    byte constant proofStorage_IPFS = 0x01;
+    uint8 constant networkID_auto = 0;
+    uint8 constant networkID_mainnet = 1;
+    uint8 constant networkID_testnet = 2;
+    uint8 constant networkID_morden = 2;
+    uint8 constant networkID_consensys = 161;
+
+    OraclizeAddrResolverI OAR;
+
+    OraclizeI oraclize;
+    modifier oraclizeAPI {
+        if(address(OAR)==0) oraclize_setNetwork(networkID_auto);
+        oraclize = OraclizeI(OAR.getAddress());
+        _;
+    }
+    modifier coupon(string code){
+        oraclize = OraclizeI(OAR.getAddress());
+        oraclize.useCoupon(code);
+        _;
+    }
+
+    function oraclize_setNetwork(uint8 networkID) internal returns(bool){
+        if (getCodeSize(0x1d3b2638a7cc9f2cb3d298a3da7a90b67e5506ed)>0){ //mainnet
+            OAR = OraclizeAddrResolverI(0x1d3b2638a7cc9f2cb3d298a3da7a90b67e5506ed);
+            return true;
+        }
+        if (getCodeSize(0xc03a2615d5efaf5f49f60b7bb6583eaec212fdf1)>0){ //ropsten testnet
+            OAR = OraclizeAddrResolverI(0xc03a2615d5efaf5f49f60b7bb6583eaec212fdf1);
+            return true;
+        }
+        if (getCodeSize(0x20e12a1f859b3feae5fb2a0a32c18f5a65555bbf)>0){ //ether.camp ide
+            OAR = OraclizeAddrResolverI(0x20e12a1f859b3feae5fb2a0a32c18f5a65555bbf);
+            return true;
+        }
+        if (getCodeSize(0x93bbbe5ce77034e3095f0479919962a903f898ad)>0){ //norsborg testnet
+            OAR = OraclizeAddrResolverI(0x93bbbe5ce77034e3095f0479919962a903f898ad);
+            return true;
+        }
+        if (getCodeSize(0x51efaf4c8b3c9afbd5ab9f4bbc82784ab6ef8faa)>0){ //browser-solidity
+            OAR = OraclizeAddrResolverI(0x51efaf4c8b3c9afbd5ab9f4bbc82784ab6ef8faa);
+            return true;
+        }
+        return false;
+    }
+
+    function __callback(bytes32 myid, string result) {
+        __callback(myid, result, new bytes(0));
+    }
+    function __callback(bytes32 myid, string result, bytes proof) {
+    }
+
+    function oraclize_getPrice(string datasource) oraclizeAPI internal returns (uint){
+        return oraclize.getPrice(datasource);
+    }
+    function oraclize_getPrice(string datasource, uint gaslimit) oraclizeAPI internal returns (uint){
+        return oraclize.getPrice(datasource, gaslimit);
+    }
+
+    function oraclize_query(string datasource, string arg) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource);
+        if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
+        return oraclize.query.value(price)(0, datasource, arg);
+    }
+    function oraclize_query(uint timestamp, string datasource, string arg) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource);
+        if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
+        return oraclize.query.value(price)(timestamp, datasource, arg);
+    }
+    function oraclize_query(uint timestamp, string datasource, string arg, uint gaslimit) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource, gaslimit);
+        if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
+        return oraclize.query_withGasLimit.value(price)(timestamp, datasource, arg, gaslimit);
+    }
+    function oraclize_query(string datasource, string arg, uint gaslimit) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource, gaslimit);
+        if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
+        return oraclize.query_withGasLimit.value(price)(0, datasource, arg, gaslimit);
+    }
+    function oraclize_query(string datasource, string arg1, string arg2) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource);
+        if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
+        return oraclize.query2.value(price)(0, datasource, arg1, arg2);
+    }
+    function oraclize_query(uint timestamp, string datasource, string arg1, string arg2) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource);
+        if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
+        return oraclize.query2.value(price)(timestamp, datasource, arg1, arg2);
+    }
+    function oraclize_query(uint timestamp, string datasource, string arg1, string arg2, uint gaslimit) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource, gaslimit);
+        if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
+        return oraclize.query2_withGasLimit.value(price)(timestamp, datasource, arg1, arg2, gaslimit);
+    }
+    function oraclize_query(string datasource, string arg1, string arg2, uint gaslimit) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource, gaslimit);
+        if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
+        return oraclize.query2_withGasLimit.value(price)(0, datasource, arg1, arg2, gaslimit);
+    }
+    function oraclize_cbAddress() oraclizeAPI internal returns (address){
+        return oraclize.cbAddress();
+    }
+    function oraclize_setProof(byte proofP) oraclizeAPI internal {
+        return oraclize.setProofType(proofP);
+    }
+    function oraclize_setCustomGasPrice(uint gasPrice) oraclizeAPI internal {
+        return oraclize.setCustomGasPrice(gasPrice);
+    }
+    function oraclize_setConfig(bytes32 config) oraclizeAPI internal {
+        return oraclize.setConfig(config);
+    }
+
+    function getCodeSize(address _addr) constant internal returns(uint _size) {
+        assembly {
+            _size := extcodesize(_addr)
+        }
+    }
+
+
+    function parseAddr(string _a) internal returns (address){
+        bytes memory tmp = bytes(_a);
+        uint160 iaddr = 0;
+        uint160 b1;
+        uint160 b2;
+        for (uint i=2; i<2+2*20; i+=2){
+            iaddr *= 256;
+            b1 = uint160(tmp[i]);
+            b2 = uint160(tmp[i+1]);
+            if ((b1 >= 97)&&(b1 <= 102)) b1 -= 87;
+            else if ((b1 >= 48)&&(b1 <= 57)) b1 -= 48;
+            if ((b2 >= 97)&&(b2 <= 102)) b2 -= 87;
+            else if ((b2 >= 48)&&(b2 <= 57)) b2 -= 48;
+            iaddr += (b1*16+b2);
+        }
+        return address(iaddr);
+    }
+
+
+    function strCompare(string _a, string _b) internal returns (int){
+        bytes memory a = bytes(_a);
+        bytes memory b = bytes(_b);
+        uint minLength = a.length;
+        if (b.length < minLength) minLength = b.length;
+        for (uint i = 0; i < minLength; i ++)
+            if (a[i] < b[i])
+                return -1;
+            else if (a[i] > b[i])
+                return 1;
+        if (a.length < b.length)
+            return -1;
+        else if (a.length > b.length)
+            return 1;
+        else
+            return 0;
+   }
+
+    function indexOf(string _haystack, string _needle) internal returns (int)
+    {
+        bytes memory h = bytes(_haystack);
+        bytes memory n = bytes(_needle);
+        if(h.length < 1 || n.length < 1 || (n.length > h.length))
+            return -1;
+        else if(h.length > (2**128 -1))
+            return -1;
+        else
+        {
+            uint subindex = 0;
+            for (uint i = 0; i < h.length; i ++)
+            {
+                if (h[i] == n[0])
+                {
+                    subindex = 1;
+                    while(subindex < n.length && (i + subindex) < h.length && h[i + subindex] == n[subindex])
+                    {
+                        subindex++;
+                    }
+                    if(subindex == n.length)
+                        return int(i);
+                }
+            }
+            return -1;
+        }
+    }
+
+    function strConcat(string _a, string _b, string _c, string _d, string _e) internal returns (string){
+        bytes memory _ba = bytes(_a);
+        bytes memory _bb = bytes(_b);
+        bytes memory _bc = bytes(_c);
+        bytes memory _bd = bytes(_d);
+        bytes memory _be = bytes(_e);
+        string memory abcde = new string(_ba.length + _bb.length + _bc.length + _bd.length + _be.length);
+        bytes memory babcde = bytes(abcde);
+        uint k = 0;
+        for (uint i = 0; i < _ba.length; i++) babcde[k++] = _ba[i];
+        for (i = 0; i < _bb.length; i++) babcde[k++] = _bb[i];
+        for (i = 0; i < _bc.length; i++) babcde[k++] = _bc[i];
+        for (i = 0; i < _bd.length; i++) babcde[k++] = _bd[i];
+        for (i = 0; i < _be.length; i++) babcde[k++] = _be[i];
+        return string(babcde);
+    }
+
+    function strConcat(string _a, string _b, string _c, string _d) internal returns (string) {
+        return strConcat(_a, _b, _c, _d, "");
+    }
+
+    function strConcat(string _a, string _b, string _c) internal returns (string) {
+        return strConcat(_a, _b, _c, "", "");
+    }
+
+    function strConcat(string _a, string _b) internal returns (string) {
+        return strConcat(_a, _b, "", "", "");
+    }
+
+    // parseInt
+    function parseInt(string _a) internal returns (uint) {
+        return parseInt(_a, 0);
+    }
+
+    // parseInt(parseFloat*10^_b)
+    function parseInt(string _a, uint _b) internal returns (uint) {
+        bytes memory bresult = bytes(_a);
+        uint mint = 0;
+        bool decimals = false;
+        for (uint i=0; i<bresult.length; i++){
+            if ((bresult[i] >= 48)&&(bresult[i] <= 57)){
+                if (decimals){
+                   if (_b == 0) break;
+                    else _b--;
+                }
+                mint *= 10;
+                mint += uint(bresult[i]) - 48;
+            } else if (bresult[i] == 46) decimals = true;
+        }
+        if (_b > 0) mint *= 10**_b;
+        return mint;
+    }
+
+    function uint2str(uint i) internal returns (string){
+        if (i == 0) return "0";
+        uint j = i;
+        uint len;
+        while (j != 0){
+            len++;
+            j /= 10;
+        }
+        bytes memory bstr = new bytes(len);
+        uint k = len - 1;
+        while (i != 0){
+            bstr[k--] = byte(48 + i % 10);
+            i /= 10;
+        }
+        return string(bstr);
+    }
+
+
+
+}
+// </ORACLIZE_API>
+
+
+
 contract Master {
     address public owner;
     Lottery[] public lotteries;
@@ -73,7 +356,7 @@ contract Master {
     }
 }
 
-contract Lottery {
+contract Lottery is usingOraclize {
     uint public etherContribution;
     uint public maxPlayers;
     address owner;
@@ -84,8 +367,11 @@ contract Lottery {
     // ORACLIZE
     string public result;
     bytes32 public oraclizeID;
-    function __callback(bytes32 _oraclizeID, string _result) {
-        if(msg.sender != oraclize_cbAddress()) throw;
+
+    // So you know which specific request to the service is getting called back
+    function __callback(bytes32 _oraclizeID, string _result) public {
+        emit eLog(msg.sender, msg.sender, "__callback RESULT...");
+        if(msg.sender != oraclize_cbAddress()) revert(); // throw;
         result = _result;
     }
     
@@ -110,10 +396,13 @@ contract Lottery {
             activePlayers.push(player);
         } else {
             emit eLog(msg.sender, player, "etherAmount sent was not the same as minEther"); // METP, minEther ToPlayWith
+            // TODO revert(); or throw;
         }
         if (activePlayers.length == maxPlayers) {
             // ORACLIZE
-            oraclizeID = oraclize_query("WolframAlpha", "flip a coin");
+            // id of the specific request to the service...
+            // oraclizeID = oraclize_query("WolframAlpha", "flip a coin"); // data source and data input string,  URL is defualt
+            // emit eLog(msg.sender, player, result);
 
             // 1 - randomWinner() Winner should receive money successfully before the House takes a Fee
             uint randomNumber = 1;
@@ -149,3 +438,4 @@ contract Lottery {
         return owner;
     }
 }
+

--- a/solidity/Master.sol
+++ b/solidity/Master.sol
@@ -370,6 +370,7 @@ contract Lottery is usingOraclize {
 
     // So you know which specific request to the service is getting called back
     function __callback(bytes32 _oraclizeID, string _result) public {
+        // TODO logger using bytes32 _oraclizeID?
         emit eLog(msg.sender, msg.sender, "__callback RESULT...");
         if(msg.sender != oraclize_cbAddress()) revert(); // throw;
         result = _result;
@@ -390,6 +391,12 @@ contract Lottery is usingOraclize {
         masterContractAddress = msg.sender;
     }
 
+
+    // 2 - payouts()
+    //uint numerator = 1;
+    //uint denominator = 100;
+    //uint fee = (this.balance * numerator) / denominator;
+    //owner.transfer(fee); // does this substract it from this.balance??? 
     function addActivePlayer(address player, uint etherAmount) public payable {
         if (etherAmount == etherContribution) {
             emit eLog(msg.sender, player, "value equals ether contribution, add player");
@@ -401,24 +408,21 @@ contract Lottery is usingOraclize {
         if (activePlayers.length == maxPlayers) {
             // ORACLIZE
             // id of the specific request to the service...
-            // oraclizeID = oraclize_query("WolframAlpha", "flip a coin"); // data source and data input string,  URL is defualt
+            oraclizeID = oraclize_query("WolframAlpha", "flip a coin"); // data source and data input string,  URL is defualt
             // emit eLog(msg.sender, player, result);
 
+            // PUT BACK...
             // 1 - randomWinner() Winner should receive money successfully before the House takes a Fee
-            uint randomNumber = 1;
-            address winner = activePlayers[randomNumber];
-            winner.transfer(address(this).balance);
+            // uint randomNumber = 1;
+            // address winner = activePlayers[randomNumber];
+            // winner.transfer(address(this).balance);
             
-            // 2 - payouts()
-            //uint numerator = 1;
-            //uint denominator = 100;
-            //uint fee = (this.balance * numerator) / denominator;
-            //owner.transfer(fee); // does this substract it from this.balance??? 
-            
+
+            // PUT BACK...
             // 3 - remove from MasterContract lotteries[] and selfdestruct() https://en.wikiquote.org/wiki/Inspector_Gadget
-            emit eLog(msg.sender, player, "the lottery was filled. payout made...self-destructing"); // this wont run if you call it after selfdestruct, for obvious reason
-            master.removeLottery();
-            selfdestruct(address(this)); // doesnt remove the lottery from MasterContract.sol's Lottery[]
+            // emit eLog(msg.sender, player, "the lottery was filled. payout made...self-destructing"); // this wont run if you call it after selfdestruct, for obvious reason
+            // master.removeLottery();
+            // selfdestruct(address(this)); // doesnt remove the lottery from MasterContract.sol's Lottery[]
             //
         } else {
             emit eLog(msg.sender, player, "the lottery was not filled yet");

--- a/solidity/Master.sol
+++ b/solidity/Master.sol
@@ -376,7 +376,6 @@ contract Lottery is usingOraclize {
         result = _result;
     }
     
-    
     event eLog (
         address indexed _from,
         address indexed player,
@@ -392,38 +391,39 @@ contract Lottery is usingOraclize {
     }
 
 
-    // 2 - payouts()
-    //uint numerator = 1;
-    //uint denominator = 100;
-    //uint fee = (this.balance * numerator) / denominator;
-    //owner.transfer(fee); // does this substract it from this.balance??? 
+    /*
+    06/08/18 Hold-off https://github.com/thinkocapo/full-stack-fund/pull/29 https://github.com/thinkocapo/full-stack-fund/issues/30 
+    oraclizeID = oraclize_query("WolframAlpha", "flip a coin"); // data source and data input string,  URL is defualt. ID of the request, compare it in the __callback
+    __callback from oraclize could call the rest of this...
+    */
     function addActivePlayer(address player, uint etherAmount) public payable {
         if (etherAmount == etherContribution) {
             emit eLog(msg.sender, player, "value equals ether contribution, add player");
             activePlayers.push(player);
         } else {
             emit eLog(msg.sender, player, "etherAmount sent was not the same as minEther"); // METP, minEther ToPlayWith
-            // TODO revert(); or throw;
+            revert();
         }
         if (activePlayers.length == maxPlayers) {
-            // ORACLIZE
-            // id of the specific request to the service...
-            oraclizeID = oraclize_query("WolframAlpha", "flip a coin"); // data source and data input string,  URL is defualt
-            // emit eLog(msg.sender, player, result);
+            
+            // 1 Select Winner - and should receive money successfully before the House takes a Fee
+            uint randomNumber = 1;
+            address winner = activePlayers[randomNumber];
 
-            // PUT BACK...
-            // 1 - randomWinner() Winner should receive money successfully before the House takes a Fee
-            // uint randomNumber = 1;
-            // address winner = activePlayers[randomNumber];
-            // winner.transfer(address(this).balance);
+            // 2 Payouts - House Fee and Winner Payout
+            // Calculate House Fee 1%...
+                //uint numerator = 1;
+                //uint denominator = 100;
+                //uint fee = (this.balance * numerator) / denominator;
+            //owner.transfer(fee); // does this substract it from this.balance?
+            winner.transfer(address(this).balance);
             
 
-            // PUT BACK...
-            // 3 - remove from MasterContract lotteries[] and selfdestruct() https://en.wikiquote.org/wiki/Inspector_Gadget
-            // emit eLog(msg.sender, player, "the lottery was filled. payout made...self-destructing"); // this wont run if you call it after selfdestruct, for obvious reason
-            // master.removeLottery();
-            // selfdestruct(address(this)); // doesnt remove the lottery from MasterContract.sol's Lottery[]
-            //
+            // 3 - Call selfdestruct and remove the lottery from MasterContract's lotteries[]
+            emit eLog(msg.sender, player, "the lottery was filled. payout made...self-destructing"); 
+            master.removeLottery();
+            selfdestruct(address(this)); // https://en.wikiquote.org/wiki/Inspector_Gadget
+            // can't call eLog or anything on the lottery anymore, because it no longer exists
         } else {
             emit eLog(msg.sender, player, "the lottery was not filled yet");
         }

--- a/solidity/Master.sol
+++ b/solidity/Master.sol
@@ -80,7 +80,16 @@ contract Lottery {
     address[] public activePlayers;
     address masterContractAddress;
     Master master;
-
+    
+    // ORACLIZE
+    string public result;
+    bytes32 public oraclizeID;
+    function __callback(bytes32 _oraclizeID, string _result) {
+        if(msg.sender != oraclize_cbAddress()) throw;
+        result = _result;
+    }
+    
+    
     event eLog (
         address indexed _from,
         address indexed player,
@@ -103,6 +112,9 @@ contract Lottery {
             emit eLog(msg.sender, player, "etherAmount sent was not the same as minEther"); // METP, minEther ToPlayWith
         }
         if (activePlayers.length == maxPlayers) {
+            // ORACLIZE
+            oraclizeID = oraclize_query("WolframAlpha", "flip a coin");
+
             // 1 - randomWinner() Winner should receive money successfully before the House takes a Fee
             uint randomNumber = 1;
             address winner = activePlayers[randomNumber];

--- a/solidity/OraclizeAPI.sol
+++ b/solidity/OraclizeAPI.sol
@@ -28,7 +28,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-pragma solidity ^0.4.0;//please import oraclizeAPI_pre0.4.sol when solidity < 0.4.0
+pragma solidity ^0.4.0; //please import oraclizeAPI_pre0.4.sol when solidity < 0.4.0
 
 contract OraclizeI {
     address public cbAddress;
@@ -63,8 +63,9 @@ contract usingOraclize {
     
     OraclizeI oraclize;
     modifier oraclizeAPI {
-        if((address(OAR)==0)||(getCodeSize(address(OAR))==0)) oraclize_setNetwork(networkID_auto);
-        oraclize = OraclizeI(OAR.getAddress());
+        // TODO...
+        // if((address(OAR)==0)||(getCodeSize(address(OAR))==0)) oraclize_setNetwork(networkID_auto);
+        // oraclize = OraclizeI(OAR.getAddress());
         _;
     }
     modifier coupon(string code){
@@ -112,7 +113,8 @@ contract usingOraclize {
     
     function oraclize_query(string datasource, string arg) oraclizeAPI internal returns (bytes32 id){
         uint price = oraclize.getPrice(datasource);
-        if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
+        // LOG IN HERE...?
+        // if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
         return oraclize.query.value(price)(0, datasource, arg);
     }
     function oraclize_query(uint timestamp, string datasource, string arg) oraclizeAPI internal returns (bytes32 id){

--- a/solidity/OraclizeAPI.sol
+++ b/solidity/OraclizeAPI.sol
@@ -1,0 +1,277 @@
+pragma solidity ^0.4.0;
+
+contract OraclizeI {
+    address public cbAddress;
+    function query(uint _timestamp, string _datasource, string _arg) payable returns (bytes32 _id);
+    function query_withGasLimit(uint _timestamp, string _datasource, string _arg, uint _gaslimit) payable returns (bytes32 _id);
+    function query2(uint _timestamp, string _datasource, string _arg1, string _arg2) payable returns (bytes32 _id);
+    function query2_withGasLimit(uint _timestamp, string _datasource, string _arg1, string _arg2, uint _gaslimit) payable returns (bytes32 _id);
+    function getPrice(string _datasource) returns (uint _dsprice);
+    function getPrice(string _datasource, uint gaslimit) returns (uint _dsprice);
+    function useCoupon(string _coupon);
+    function setProofType(byte _proofType);
+    function setConfig(bytes32 _config);
+    function setCustomGasPrice(uint _gasPrice);
+}
+contract OraclizeAddrResolverI {
+    function getAddress() returns (address _addr);
+}
+contract usingOraclize {
+    uint constant day = 60*60*24;
+    uint constant week = 60*60*24*7;
+    uint constant month = 60*60*24*30;
+    byte constant proofType_NONE = 0x00;
+    byte constant proofType_TLSNotary = 0x10;
+    byte constant proofStorage_IPFS = 0x01;
+    uint8 constant networkID_auto = 0;
+    uint8 constant networkID_mainnet = 1;
+    uint8 constant networkID_testnet = 2;
+    uint8 constant networkID_morden = 2;
+    uint8 constant networkID_consensys = 161;
+
+    OraclizeAddrResolverI OAR;
+
+    OraclizeI oraclize;
+    modifier oraclizeAPI {
+        if(address(OAR)==0) oraclize_setNetwork(networkID_auto);
+        oraclize = OraclizeI(OAR.getAddress());
+        _;
+    }
+    modifier coupon(string code){
+        oraclize = OraclizeI(OAR.getAddress());
+        oraclize.useCoupon(code);
+        _;
+    }
+
+    function oraclize_setNetwork(uint8 networkID) internal returns(bool){
+        if (getCodeSize(0x1d3b2638a7cc9f2cb3d298a3da7a90b67e5506ed)>0){ //mainnet
+            OAR = OraclizeAddrResolverI(0x1d3b2638a7cc9f2cb3d298a3da7a90b67e5506ed);
+            return true;
+        }
+        if (getCodeSize(0xc03a2615d5efaf5f49f60b7bb6583eaec212fdf1)>0){ //ropsten testnet
+            OAR = OraclizeAddrResolverI(0xc03a2615d5efaf5f49f60b7bb6583eaec212fdf1);
+            return true;
+        }
+        if (getCodeSize(0x20e12a1f859b3feae5fb2a0a32c18f5a65555bbf)>0){ //ether.camp ide
+            OAR = OraclizeAddrResolverI(0x20e12a1f859b3feae5fb2a0a32c18f5a65555bbf);
+            return true;
+        }
+        if (getCodeSize(0x93bbbe5ce77034e3095f0479919962a903f898ad)>0){ //norsborg testnet
+            OAR = OraclizeAddrResolverI(0x93bbbe5ce77034e3095f0479919962a903f898ad);
+            return true;
+        }
+        if (getCodeSize(0x51efaf4c8b3c9afbd5ab9f4bbc82784ab6ef8faa)>0){ //browser-solidity
+            OAR = OraclizeAddrResolverI(0x51efaf4c8b3c9afbd5ab9f4bbc82784ab6ef8faa);
+            return true;
+        }
+        return false;
+    }
+
+    function __callback(bytes32 myid, string result) {
+        __callback(myid, result, new bytes(0));
+    }
+    function __callback(bytes32 myid, string result, bytes proof) {
+    }
+
+    function oraclize_getPrice(string datasource) oraclizeAPI internal returns (uint){
+        return oraclize.getPrice(datasource);
+    }
+    function oraclize_getPrice(string datasource, uint gaslimit) oraclizeAPI internal returns (uint){
+        return oraclize.getPrice(datasource, gaslimit);
+    }
+
+    function oraclize_query(string datasource, string arg) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource);
+        if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
+        return oraclize.query.value(price)(0, datasource, arg);
+    }
+    function oraclize_query(uint timestamp, string datasource, string arg) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource);
+        if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
+        return oraclize.query.value(price)(timestamp, datasource, arg);
+    }
+    function oraclize_query(uint timestamp, string datasource, string arg, uint gaslimit) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource, gaslimit);
+        if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
+        return oraclize.query_withGasLimit.value(price)(timestamp, datasource, arg, gaslimit);
+    }
+    function oraclize_query(string datasource, string arg, uint gaslimit) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource, gaslimit);
+        if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
+        return oraclize.query_withGasLimit.value(price)(0, datasource, arg, gaslimit);
+    }
+    function oraclize_query(string datasource, string arg1, string arg2) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource);
+        if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
+        return oraclize.query2.value(price)(0, datasource, arg1, arg2);
+    }
+    function oraclize_query(uint timestamp, string datasource, string arg1, string arg2) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource);
+        if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
+        return oraclize.query2.value(price)(timestamp, datasource, arg1, arg2);
+    }
+    function oraclize_query(uint timestamp, string datasource, string arg1, string arg2, uint gaslimit) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource, gaslimit);
+        if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
+        return oraclize.query2_withGasLimit.value(price)(timestamp, datasource, arg1, arg2, gaslimit);
+    }
+    function oraclize_query(string datasource, string arg1, string arg2, uint gaslimit) oraclizeAPI internal returns (bytes32 id){
+        uint price = oraclize.getPrice(datasource, gaslimit);
+        if (price > 1 ether + tx.gasprice*gaslimit) return 0; // unexpectedly high price
+        return oraclize.query2_withGasLimit.value(price)(0, datasource, arg1, arg2, gaslimit);
+    }
+    function oraclize_cbAddress() oraclizeAPI internal returns (address){
+        return oraclize.cbAddress();
+    }
+    function oraclize_setProof(byte proofP) oraclizeAPI internal {
+        return oraclize.setProofType(proofP);
+    }
+    function oraclize_setCustomGasPrice(uint gasPrice) oraclizeAPI internal {
+        return oraclize.setCustomGasPrice(gasPrice);
+    }
+    function oraclize_setConfig(bytes32 config) oraclizeAPI internal {
+        return oraclize.setConfig(config);
+    }
+
+    function getCodeSize(address _addr) constant internal returns(uint _size) {
+        assembly {
+            _size := extcodesize(_addr)
+        }
+    }
+
+
+    function parseAddr(string _a) internal returns (address){
+        bytes memory tmp = bytes(_a);
+        uint160 iaddr = 0;
+        uint160 b1;
+        uint160 b2;
+        for (uint i=2; i<2+2*20; i+=2){
+            iaddr *= 256;
+            b1 = uint160(tmp[i]);
+            b2 = uint160(tmp[i+1]);
+            if ((b1 >= 97)&&(b1 <= 102)) b1 -= 87;
+            else if ((b1 >= 48)&&(b1 <= 57)) b1 -= 48;
+            if ((b2 >= 97)&&(b2 <= 102)) b2 -= 87;
+            else if ((b2 >= 48)&&(b2 <= 57)) b2 -= 48;
+            iaddr += (b1*16+b2);
+        }
+        return address(iaddr);
+    }
+
+
+    function strCompare(string _a, string _b) internal returns (int) {
+        bytes memory a = bytes(_a);
+        bytes memory b = bytes(_b);
+        uint minLength = a.length;
+        if (b.length < minLength) minLength = b.length;
+        for (uint i = 0; i < minLength; i ++)
+            if (a[i] < b[i])
+                return -1;
+            else if (a[i] > b[i])
+                return 1;
+        if (a.length < b.length)
+            return -1;
+        else if (a.length > b.length)
+            return 1;
+        else
+            return 0;
+   }
+
+    function indexOf(string _haystack, string _needle) internal returns (int)
+    {
+        bytes memory h = bytes(_haystack);
+        bytes memory n = bytes(_needle);
+        if(h.length < 1 || n.length < 1 || (n.length > h.length))
+            return -1;
+        else if(h.length > (2**128 -1))
+            return -1;
+        else
+        {
+            uint subindex = 0;
+            for (uint i = 0; i < h.length; i ++)
+            {
+                if (h[i] == n[0])
+                {
+                    subindex = 1;
+                    while(subindex < n.length && (i + subindex) < h.length && h[i + subindex] == n[subindex])
+                    {
+                        subindex++;
+                    }
+                    if(subindex == n.length)
+                        return int(i);
+                }
+            }
+            return -1;
+        }
+    }
+
+    function strConcat(string _a, string _b, string _c, string _d, string _e) internal returns (string){
+        bytes memory _ba = bytes(_a);
+        bytes memory _bb = bytes(_b);
+        bytes memory _bc = bytes(_c);
+        bytes memory _bd = bytes(_d);
+        bytes memory _be = bytes(_e);
+        string memory abcde = new string(_ba.length + _bb.length + _bc.length + _bd.length + _be.length);
+        bytes memory babcde = bytes(abcde);
+        uint k = 0;
+        for (uint i = 0; i < _ba.length; i++) babcde[k++] = _ba[i];
+        for (i = 0; i < _bb.length; i++) babcde[k++] = _bb[i];
+        for (i = 0; i < _bc.length; i++) babcde[k++] = _bc[i];
+        for (i = 0; i < _bd.length; i++) babcde[k++] = _bd[i];
+        for (i = 0; i < _be.length; i++) babcde[k++] = _be[i];
+        return string(babcde);
+    }
+
+    function strConcat(string _a, string _b, string _c, string _d) internal returns (string) {
+        return strConcat(_a, _b, _c, _d, "");
+    }
+
+    function strConcat(string _a, string _b, string _c) internal returns (string) {
+        return strConcat(_a, _b, _c, "", "");
+    }
+
+    function strConcat(string _a, string _b) internal returns (string) {
+        return strConcat(_a, _b, "", "", "");
+    }
+
+    // parseInt
+    function parseInt(string _a) internal returns (uint) {
+        return parseInt(_a, 0);
+    }
+
+    // parseInt(parseFloat*10^_b)
+    function parseInt(string _a, uint _b) internal returns (uint) {
+        bytes memory bresult = bytes(_a);
+        uint mint = 0;
+        bool decimals = false;
+        for (uint i=0; i<bresult.length; i++){
+            if ((bresult[i] >= 48)&&(bresult[i] <= 57)){
+                if (decimals){
+                   if (_b == 0) break;
+                    else _b--;
+                }
+                mint *= 10;
+                mint += uint(bresult[i]) - 48;
+            } else if (bresult[i] == 46) decimals = true;
+        }
+        if (_b > 0) mint *= 10**_b;
+        return mint;
+    }
+
+    function uint2str(uint i) internal returns (string){
+        if (i == 0) return "0";
+        uint j = i;
+        uint len;
+        while (j != 0){
+            len++;
+            j /= 10;
+        }
+        bytes memory bstr = new bytes(len);
+        uint k = len - 1;
+        while (i != 0){
+            bstr[k--] = byte(48 + i % 10);
+            i /= 10;
+        }
+        return string(bstr);
+    }
+}

--- a/solidity/lottery.sol
+++ b/solidity/lottery.sol
@@ -39,6 +39,8 @@ contract Lottery {
         }
         if (activePlayers.length == maxPlayers) {
             // 1 - randomWinner() Winner should receive money successfully before the House takes a Fee
+            // ORACLIZE...
+            
             uint randomNumber = 1;
             address winner = activePlayers[randomNumber];
             winner.transfer(address(this).balance);

--- a/solidity/oraclizeAPIOLD.sol
+++ b/solidity/oraclizeAPIOLD.sol
@@ -1,34 +1,4 @@
-// <ORACLIZE_API>
-/*
-Copyright (c) 2015-2016 Oraclize SRL
-Copyright (c) 2016 Oraclize LTD
-
-
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-*/
-
-pragma solidity ^0.4.0;//please import oraclizeAPI_pre0.4.sol when solidity < 0.4.0
+pragma solidity ^0.4.0;
 
 contract OraclizeI {
     address public cbAddress;
@@ -60,10 +30,10 @@ contract usingOraclize {
     uint8 constant networkID_consensys = 161;
 
     OraclizeAddrResolverI OAR;
-    
+
     OraclizeI oraclize;
     modifier oraclizeAPI {
-        if((address(OAR)==0)||(getCodeSize(address(OAR))==0)) oraclize_setNetwork(networkID_auto);
+        if(address(OAR)==0) oraclize_setNetwork(networkID_auto);
         oraclize = OraclizeI(OAR.getAddress());
         _;
     }
@@ -74,42 +44,42 @@ contract usingOraclize {
     }
 
     function oraclize_setNetwork(uint8 networkID) internal returns(bool){
-        if (getCodeSize(0x1d3B2638a7cC9f2CB3D298A3DA7a90B67E5506ed)>0){ //mainnet
-            OAR = OraclizeAddrResolverI(0x1d3B2638a7cC9f2CB3D298A3DA7a90B67E5506ed);
+        if (getCodeSize(0x1d3b2638a7cc9f2cb3d298a3da7a90b67e5506ed)>0){ //mainnet
+            OAR = OraclizeAddrResolverI(0x1d3b2638a7cc9f2cb3d298a3da7a90b67e5506ed);
             return true;
         }
-        if (getCodeSize(0xc03A2615D5efaf5F49F60B7BB6583eaec212fdf1)>0){ //ropsten testnet
-            OAR = OraclizeAddrResolverI(0xc03A2615D5efaf5F49F60B7BB6583eaec212fdf1);
+        if (getCodeSize(0xc03a2615d5efaf5f49f60b7bb6583eaec212fdf1)>0){ //ropsten testnet
+            OAR = OraclizeAddrResolverI(0xc03a2615d5efaf5f49f60b7bb6583eaec212fdf1);
             return true;
         }
-        if (getCodeSize(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475)>0){ //ethereum-bridge
-            OAR = OraclizeAddrResolverI(0x6f485C8BF6fc43eA212E93BBF8ce046C7f1cb475);
+        if (getCodeSize(0x20e12a1f859b3feae5fb2a0a32c18f5a65555bbf)>0){ //ether.camp ide
+            OAR = OraclizeAddrResolverI(0x20e12a1f859b3feae5fb2a0a32c18f5a65555bbf);
             return true;
         }
-        if (getCodeSize(0x20e12A1F859B3FeaE5Fb2A0A32C18F5a65555bBF)>0){ //ether.camp ide
-            OAR = OraclizeAddrResolverI(0x20e12A1F859B3FeaE5Fb2A0A32C18F5a65555bBF);
+        if (getCodeSize(0x93bbbe5ce77034e3095f0479919962a903f898ad)>0){ //norsborg testnet
+            OAR = OraclizeAddrResolverI(0x93bbbe5ce77034e3095f0479919962a903f898ad);
             return true;
         }
-        if (getCodeSize(0x51efaF4c8B3C9AfBD5aB9F4bbC82784Ab6ef8fAA)>0){ //browser-solidity
-            OAR = OraclizeAddrResolverI(0x51efaF4c8B3C9AfBD5aB9F4bbC82784Ab6ef8fAA);
+        if (getCodeSize(0x51efaf4c8b3c9afbd5ab9f4bbc82784ab6ef8faa)>0){ //browser-solidity
+            OAR = OraclizeAddrResolverI(0x51efaf4c8b3c9afbd5ab9f4bbc82784ab6ef8faa);
             return true;
         }
         return false;
     }
-    
+
     function __callback(bytes32 myid, string result) {
         __callback(myid, result, new bytes(0));
     }
     function __callback(bytes32 myid, string result, bytes proof) {
     }
-    
+
     function oraclize_getPrice(string datasource) oraclizeAPI internal returns (uint){
         return oraclize.getPrice(datasource);
     }
     function oraclize_getPrice(string datasource, uint gaslimit) oraclizeAPI internal returns (uint){
         return oraclize.getPrice(datasource, gaslimit);
     }
-    
+
     function oraclize_query(string datasource, string arg) oraclizeAPI internal returns (bytes32 id){
         uint price = oraclize.getPrice(datasource);
         if (price > 1 ether + tx.gasprice*200000) return 0; // unexpectedly high price
@@ -158,7 +128,7 @@ contract usingOraclize {
     }
     function oraclize_setCustomGasPrice(uint gasPrice) oraclizeAPI internal {
         return oraclize.setCustomGasPrice(gasPrice);
-    }    
+    }
     function oraclize_setConfig(bytes32 config) oraclizeAPI internal {
         return oraclize.setConfig(config);
     }
@@ -205,16 +175,16 @@ contract usingOraclize {
             return 1;
         else
             return 0;
-   } 
+   }
 
     function indexOf(string _haystack, string _needle) internal returns (int)
     {
         bytes memory h = bytes(_haystack);
         bytes memory n = bytes(_needle);
-        if(h.length < 1 || n.length < 1 || (n.length > h.length)) 
+        if(h.length < 1 || n.length < 1 || (n.length > h.length))
             return -1;
         else if(h.length > (2**128 -1))
-            return -1;                                  
+            return -1;
         else
         {
             uint subindex = 0;
@@ -226,13 +196,13 @@ contract usingOraclize {
                     while(subindex < n.length && (i + subindex) < h.length && h[i + subindex] == n[subindex])
                     {
                         subindex++;
-                    }   
+                    }
                     if(subindex == n.length)
                         return int(i);
                 }
             }
             return -1;
-        }   
+        }
     }
 
     function strConcat(string _a, string _b, string _c, string _d, string _e) internal returns (string){
@@ -251,7 +221,7 @@ contract usingOraclize {
         for (i = 0; i < _be.length; i++) babcde[k++] = _be[i];
         return string(babcde);
     }
-    
+
     function strConcat(string _a, string _b, string _c, string _d) internal returns (string) {
         return strConcat(_a, _b, _c, _d, "");
     }
@@ -287,7 +257,7 @@ contract usingOraclize {
         if (_b > 0) mint *= 10**_b;
         return mint;
     }
-    
+
     function uint2str(uint i) internal returns (string){
         if (i == 0) return "0";
         uint j = i;
@@ -304,8 +274,4 @@ contract usingOraclize {
         }
         return string(bstr);
     }
-    
-    
-
 }
-// </ORACLIZE_API>


### PR DESCRIPTION
**NON-WORKING**

`import "github.com/oraclize/ethereum-api/oraclizeAPI.sol";` vs pasting in entire OraclizeAPI

might only work on Testnet and not private net?

`https://github.com/oraclize/ethereum-api/oraclizeAPI.sol` not found

try pasting the oraclizeAPI in to its own file...

try?
When the compiler is invoked, it is not only possible to specify how to discover the first element of a path, but it is possible to specify path prefix remappings so that e.g. github.com/ethereum/dapp-bin/library is remapped to /usr/local/dapp-bin/library and the compiler will read the files from there. 

need send msg.value with it? i.e. flipCoin.call()

try Solidity Remix browser version

'CoinFlipOracle.sol:CoinFlipOracle'
'oraclizeAPI.sol:OraclizeAddrResolverI':

**Compile** Using **Remix** Then paste this interface/abi into a **File** in ~/Projects/full-stack-fund